### PR TITLE
Fix multiple response.WriteHeader invocations

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -102,6 +102,8 @@ func handleWriteRequest(
 	}
 
 	dataSet := dataset.DataSet{DataSetStorage, *metaData}
+
+	// Make the dataSet available to the request context
 	c.Map(dataSet)
 
 	err = validateAuthorization(r, dataSet)
@@ -113,7 +115,11 @@ func handleWriteRequest(
 
 	jsonBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		renderError(w, http.StatusBadRequest, err.Error())
+		if gzerr, ok := err.(*gzipBombError); ok {
+			renderError(w, http.StatusRequestEntityTooLarge, gzerr.Error())
+		} else {
+			renderError(w, http.StatusBadRequest, err.Error())
+		}
 		return
 	}
 

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -536,7 +536,7 @@ var _ = Describe("Handlers", func() {
 
 					body, err := readResponseBody(response)
 					Expect(err).Should(BeNil())
-					Expect(body).Should(Equal(`{"errors":[{"detail":"Maximum upload size encounted. Treating as a potential zip bomb."}]}`))
+					Expect(body).Should(Equal(`{"errors":[{"detail":"Maximum upload size encountered. Treating as a potential zip bomb."}]}`))
 				})
 			})
 		})


### PR DESCRIPTION
This was logging warning messages:

```
http: multiple response.WriteHeader calls
```

Handlers are responsible for writing status codes; decompressor is a bit
lower-level and should return an appropriate error.
