### PR TITLE
Rename config_api package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ fmt:
 test:
 	gom exec ginkgo -cover \
 		. \
-		./pkg/config_api/ \
+		./pkg/config/ \
 		./pkg/dataset/ \
 		./pkg/handlers/ \
 		./pkg/request/ \

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/alext/tablecloth"
-	"github.com/alphagov/performance-datastore/pkg/config_api"
+	"github.com/alphagov/performance-datastore/pkg/config"
 	"github.com/alphagov/performance-datastore/pkg/handlers"
 	"net/http"
 	"os"
@@ -30,7 +30,7 @@ func main() {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	handlers.ConfigAPIClient = config_api.NewClient(configAPIURL, bearerToken)
+	handlers.ConfigAPIClient = config.NewClient(configAPIURL, bearerToken)
 	handlers.DataSetStorage = handlers.NewMongoStorage(mongoURL, databaseName)
 	handlers.StatsdClient = handlers.NewStatsDClient("localhost:8125", "datastore.")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-package config_api
+package config
 
 import (
 	"encoding/json"

--- a/pkg/config/config_api_suite_test.go
+++ b/pkg/config/config_api_suite_test.go
@@ -1,4 +1,4 @@
-package config_api_test
+package config_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestConfigApi(t *testing.T) {
+func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "ConfigApi Suite")
+	RunSpecs(t, "Config Suite")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,7 @@
-package config_api_test
+package config_test
 
 import (
-	. "github.com/alphagov/performance-datastore/pkg/config_api"
+	. "github.com/alphagov/performance-datastore/pkg/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/pkg/dataset/dataset.go
+++ b/pkg/dataset/dataset.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/alphagov/performance-datastore/pkg/config_api"
+	"github.com/alphagov/performance-datastore/pkg/config"
 	"github.com/alphagov/performance-datastore/pkg/validation"
 	"github.com/xeipuuv/gojsonschema"
 	"strings"
@@ -24,7 +24,7 @@ type DataSetStorage interface {
 // DataSet is the data type for a data set
 type DataSet struct {
 	Storage  DataSetStorage
-	MetaData config_api.DataSetMetaData
+	MetaData config.DataSetMetaData
 }
 
 // Query defines an abstraction around how we query DataSetStorage implementations

--- a/pkg/dataset/dataset_test.go
+++ b/pkg/dataset/dataset_test.go
@@ -2,7 +2,7 @@ package dataset_test
 
 import (
 	"encoding/json"
-	"github.com/alphagov/performance-datastore/pkg/config_api"
+	"github.com/alphagov/performance-datastore/pkg/config"
 	. "github.com/alphagov/performance-datastore/pkg/dataset"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -18,13 +18,13 @@ func Unmarshal(t string) map[string]interface{} {
 
 var _ = Describe("Dataset", func() {
 	var (
-		metaData config_api.DataSetMetaData
+		metaData config.DataSetMetaData
 		dataSet  DataSet
 		errors   []error
 	)
 
 	BeforeEach(func() {
-		metaData = config_api.DataSetMetaData{}
+		metaData = config.DataSetMetaData{}
 		dataSet = DataSet{nil, metaData}
 		errors = []error{}
 	})

--- a/pkg/handlers/common.go
+++ b/pkg/handlers/common.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"github.com/alphagov/performance-datastore/pkg/config_api"
+	"github.com/alphagov/performance-datastore/pkg/config"
 	"github.com/alphagov/performance-datastore/pkg/dataset"
 	"github.com/quipo/statsd"
 	"gopkg.in/unrolled/render.v1"
@@ -31,7 +31,7 @@ var (
 	DataSetStorage dataset.DataSetStorage
 
 	// ConfigAPIClient allows the client to be injected for testing purposes
-	ConfigAPIClient config_api.Client
+	ConfigAPIClient config.Client
 
 	// StatsdClient allows the statsd implementation to be injected for testing purposes
 	StatsdClient statsd.Statsd

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/Sirupsen/logrus"
-	"github.com/alphagov/performance-datastore/pkg/config_api"
+	"github.com/alphagov/performance-datastore/pkg/config"
 	"github.com/alphagov/performance-datastore/pkg/dataset"
 	"github.com/alphagov/performance-datastore/pkg/validation"
 	"github.com/go-martini/martini"
@@ -151,7 +151,7 @@ func ensureIsArray(data interface{}) []interface{} {
 	}
 }
 
-func fetch(metaData *config_api.DataSetMetaData, w http.ResponseWriter, r *http.Request) {
+func fetch(metaData *config.DataSetMetaData, w http.ResponseWriter, r *http.Request) {
 	if metaData == nil {
 		renderError(w, http.StatusNotFound, "data_set not found")
 		return
@@ -236,7 +236,7 @@ func extractBearerToken(dataSet dataset.DataSet, authorization string) (token st
 	return token, token == dataSet.BearerToken()
 }
 
-func fetchDataMetaData(dataGroup string, dataType string) (*config_api.DataSetMetaData, error) {
+func fetchDataMetaData(dataGroup string, dataType string) (*config.DataSetMetaData, error) {
 	dataTypeStart := time.Now()
 	defer statsDTiming(fmt.Sprintf("config.%s.%s", dataGroup, dataType),
 		dataTypeStart, time.Now())

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-martini/martini"
 	"github.com/quipo/statsd"
 
-	"github.com/alphagov/performance-datastore/pkg/config_api"
+	"github.com/alphagov/performance-datastore/pkg/config"
 	"github.com/alphagov/performance-datastore/pkg/dataset"
 	"github.com/alphagov/performance-datastore/pkg/handlers"
 
@@ -62,23 +62,23 @@ func newTestDataSetStorage(alive bool, lastUpdated *time.Time, exists bool, err 
 
 type TestConfigAPIClient struct {
 	Error    error
-	MetaData *config_api.DataSetMetaData
-	DataSets []config_api.DataSetMetaData
+	MetaData *config.DataSetMetaData
+	DataSets []config.DataSetMetaData
 }
 
-func newTestConfigAPIClient(err error, metaData *config_api.DataSetMetaData, datasets []config_api.DataSetMetaData) config_api.Client {
+func newTestConfigAPIClient(err error, metaData *config.DataSetMetaData, datasets []config.DataSetMetaData) config.Client {
 	return &TestConfigAPIClient{err, metaData, datasets}
 }
 
-func (c *TestConfigAPIClient) DataSet(name string) (*config_api.DataSetMetaData, error) {
+func (c *TestConfigAPIClient) DataSet(name string) (*config.DataSetMetaData, error) {
 	return c.MetaData, c.Error
 }
 
-func (c *TestConfigAPIClient) DataType(group string, dataType string) (*config_api.DataSetMetaData, error) {
+func (c *TestConfigAPIClient) DataType(group string, dataType string) (*config.DataSetMetaData, error) {
 	return c.MetaData, c.Error
 }
 
-func (c *TestConfigAPIClient) ListDataSets() ([]config_api.DataSetMetaData, error) {
+func (c *TestConfigAPIClient) ListDataSets() ([]config.DataSetMetaData, error) {
 	return c.DataSets, c.Error
 }
 
@@ -250,9 +250,9 @@ var _ = Describe("Handlers", func() {
 			defer testServer.Close()
 
 			handlers.ConfigAPIClient = newTestConfigAPIClient(nil, nil,
-				[]config_api.DataSetMetaData{
-					config_api.DataSetMetaData{},
-					config_api.DataSetMetaData{}})
+				[]config.DataSetMetaData{
+					config.DataSetMetaData{},
+					config.DataSetMetaData{}})
 
 			response, err := http.Get(testServer.URL)
 			Expect(err).To(BeNil())
@@ -267,14 +267,14 @@ var _ = Describe("Handlers", func() {
 			testServer := testHandlerServer(handlers.DataSetStatusHandler)
 			defer testServer.Close()
 
-			stale := config_api.DataSetMetaData{}
+			stale := config.DataSetMetaData{}
 			stale.Published = true
 			maxExpectedAge := int64(8400)
 			stale.MaxExpectedAge = &maxExpectedAge
 
 			handlers.ConfigAPIClient = newTestConfigAPIClient(nil, nil,
-				[]config_api.DataSetMetaData{
-					config_api.DataSetMetaData{},
+				[]config.DataSetMetaData{
+					config.DataSetMetaData{},
 					stale})
 
 			response, err := http.Get(testServer.URL)
@@ -304,7 +304,7 @@ var _ = Describe("Handlers", func() {
 		Context("When there is no valid Authorization credentials", func() {
 			It("Should fail with an Authorization required response when there is no Authorization header", func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{Name: "the-dataset"},
+					&config.DataSetMetaData{Name: "the-dataset"},
 					nil)
 				req, err := http.NewRequest("POST", testServer.URL+"/data/a-data-group/a-data-type", nil)
 
@@ -321,7 +321,7 @@ var _ = Describe("Handlers", func() {
 
 			It("Should fail with an Authorization required response when the Authorization header isn't a valid bearer token", func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{Name: "the-dataset"},
+					&config.DataSetMetaData{Name: "the-dataset"},
 					nil)
 				req, err := http.NewRequest("POST", testServer.URL+"/data/a-data-group/a-data-type", nil)
 				req.Header.Add("Authorization", "Not a bearer token")
@@ -339,7 +339,7 @@ var _ = Describe("Handlers", func() {
 
 			It("Should fail with an Authorization required response when the Authorization bearer token does not match the data set bearer token", func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{Name: "the-dataset"},
+					&config.DataSetMetaData{Name: "the-dataset"},
 					nil)
 				req, err := http.NewRequest("POST", testServer.URL+"/data/a-data-group/a-data-type", nil)
 				req.Header.Add("Authorization", "Not a bearer token")
@@ -357,7 +357,7 @@ var _ = Describe("Handlers", func() {
 
 			It("Should fail with an Authorization required response when the Authorization bearer token does not match the data set bearer token", func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{BearerToken: "the-bearer-token", Name: "the-dataset"},
+					&config.DataSetMetaData{BearerToken: "the-bearer-token", Name: "the-dataset"},
 					nil)
 				req, err := http.NewRequest("POST", testServer.URL+"/data/a-data-group/a-data-type", nil)
 				req.Header.Add("Authorization", "Not a bearer token")
@@ -377,7 +377,7 @@ var _ = Describe("Handlers", func() {
 		Context("When there are valid Authorization credentials", func() {
 			BeforeEach(func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{BearerToken: "the-bearer-token", Name: "the-dataset"},
+					&config.DataSetMetaData{BearerToken: "the-bearer-token", Name: "the-dataset"},
 					nil)
 			})
 
@@ -558,7 +558,7 @@ var _ = Describe("Handlers", func() {
 		Context("When there is no valid Authorization credentials", func() {
 			It("Should fail with an Authorization required response when there is no Authorization header", func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{},
+					&config.DataSetMetaData{},
 					nil)
 				req, err := http.NewRequest("PUT", testServer.URL+"/data/a-data-group/a-data-type", nil)
 
@@ -575,7 +575,7 @@ var _ = Describe("Handlers", func() {
 
 			It("Should fail with an Authorization required response when the Authorization header isn't a valid bearer token", func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{Name: "the-dataset"},
+					&config.DataSetMetaData{Name: "the-dataset"},
 					nil)
 				req, err := http.NewRequest("PUT", testServer.URL+"/data/a-data-group/a-data-type", nil)
 				req.Header.Add("Authorization", "Not a bearer token")
@@ -593,7 +593,7 @@ var _ = Describe("Handlers", func() {
 
 			It("Should fail with an Authorization required response when the Authorization bearer token does not match the data set bearer token", func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{Name: "the-dataset"},
+					&config.DataSetMetaData{Name: "the-dataset"},
 					nil)
 				req, err := http.NewRequest("PUT", testServer.URL+"/data/a-data-group/a-data-type", nil)
 				req.Header.Add("Authorization", "Not a bearer token")
@@ -610,7 +610,7 @@ var _ = Describe("Handlers", func() {
 
 			It("Should fail with an Authorization required response when the Authorization bearer token does not match the data set bearer token", func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{BearerToken: "the-bearer-token", Name: "the-dataset"},
+					&config.DataSetMetaData{BearerToken: "the-bearer-token", Name: "the-dataset"},
 					nil)
 				req, err := http.NewRequest("PUT", testServer.URL+"/data/a-data-group/a-data-type", nil)
 				req.Header.Add("Authorization", "Not a bearer token")
@@ -629,7 +629,7 @@ var _ = Describe("Handlers", func() {
 		Context("When there are valid Authorization credentials", func() {
 			BeforeEach(func() {
 				handlers.ConfigAPIClient = newTestConfigAPIClient(nil,
-					&config_api.DataSetMetaData{
+					&config.DataSetMetaData{
 						BearerToken: "the-bearer-token",
 						Name:        "the-dataset"},
 					nil)

--- a/pkg/handlers/healthcheck.go
+++ b/pkg/handlers/healthcheck.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/alphagov/performance-datastore/pkg/config_api"
+	"github.com/alphagov/performance-datastore/pkg/config"
 	"github.com/alphagov/performance-datastore/pkg/dataset"
 	"net/http"
 	"sync"
@@ -71,7 +71,7 @@ func checkFreshness(
 	}
 }
 
-func collectStaleness(datasets []config_api.DataSetMetaData) (failing chan DataSetStatus) {
+func collectStaleness(datasets []config.DataSetMetaData) (failing chan DataSetStatus) {
 	failing = make(chan DataSetStatus, len(datasets))
 
 	if len(datasets) == 0 {


### PR DESCRIPTION
Not standard Go to have an underscore in the package name.
