### PR TITLE
Make tools work with Gom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 .PHONY: deps test build
 
 BINARY := performance-datastore
-current_dir := $(shell pwd)
+IMPORT_BASE := github.com/alphagov
+IMPORT_PATH := $(IMPORT_BASE)/performance-datastore
 
-all: deps fmt test build
+all: deps _vendor fmt test build
 
 deps:
 	go get github.com/mattn/gom
 	go get github.com/onsi/ginkgo/ginkgo
 	go get code.google.com/p/go.tools/cmd/cover
-	gom -test install
 
 fmt:
 	gofmt -w=1 *.go
@@ -25,10 +25,19 @@ test:
 		./pkg/validation/
 	# rewrite the generated .coverprofile files so that you can run the command
 	# gom tool cover -html=./pkg/handlers/handlers.coverprofile and other lovely stuff
-	find . -name '*.coverprofile' -type f -exec sed -i '' 's|_'$(current_dir)'|\.|' {} \;
+	find . -name '*.coverprofile' -type f -exec sed -i '' 's|_'$(CURDIR)'|\.|' {} \;
 
 build:
 	gom build -o $(BINARY)
 
 clean:
 	rm -rf $(BINARY)
+
+_vendor: Gomfile _vendor/src/$(IMPORT_PATH)
+	gom -test install
+	touch _vendor
+
+_vendor/src/$(IMPORT_PATH):
+	rm -f _vendor/src/$(IMPORT_PATH)
+	mkdir -p _vendor/src/$(IMPORT_BASE)
+	ln -s $(CURDIR) _vendor/src/$(IMPORT_PATH)

--- a/pkg/config/config_api_suite_test.go
+++ b/pkg/config/config_api_suite_test.go
@@ -1,4 +1,4 @@
-package config_test
+package config
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,6 @@
-package config_test
+package config
 
 import (
-	. "github.com/alphagov/performance-datastore/pkg/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/pkg/dataset/dataset_suite_test.go
+++ b/pkg/dataset/dataset_suite_test.go
@@ -1,4 +1,4 @@
-package dataset_test
+package dataset
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/pkg/dataset/dataset_test.go
+++ b/pkg/dataset/dataset_test.go
@@ -1,9 +1,8 @@
-package dataset_test
+package dataset
 
 import (
 	"encoding/json"
 	"github.com/alphagov/performance-datastore/pkg/config"
-	. "github.com/alphagov/performance-datastore/pkg/dataset"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"time"

--- a/pkg/handlers/handlers_suite_test.go
+++ b/pkg/handlers/handlers_suite_test.go
@@ -1,4 +1,4 @@
-package handlers_test
+package handlers
 
 import (
 	"io/ioutil"

--- a/pkg/request/request_test.go
+++ b/pkg/request/request_test.go
@@ -1,4 +1,4 @@
-package request_test
+package request
 
 import (
 	"fmt"
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-
-	. "github.com/alphagov/performance-datastore/pkg/request"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/validation/validation_suite_test.go
+++ b/pkg/validation/validation_suite_test.go
@@ -1,4 +1,4 @@
-package validation_test
+package validation
 
 import (
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
Allow `cover` and similar things to work locally, off the GOPATH.

Symlink the project source into the _vendor directory, so that names
work properly.

Tried using relative local imports, but that way seems to lie madness.
