### PR TITLE
Add more test coverage for handlers

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -64,7 +64,11 @@ func CreateHandler(c martini.Context, w http.ResponseWriter, r *http.Request, pa
 		errors := dataSet.Append(jsonArray)
 
 		if len(errors) > 0 {
-			renderError(w, http.StatusBadRequest, "All the errors")
+			errorMessages := make([]string, len(errors))
+			for i, e := range errors {
+				errorMessages[i] = e.Error()
+			}
+			renderError(w, http.StatusBadRequest, errorMessages...)
 		} else {
 			renderer.JSON(w, http.StatusOK, map[string]string{"status": "OK"})
 		}
@@ -126,7 +130,7 @@ func handleWriteRequest(
 	}
 
 	if len(jsonBytes) == 0 {
-		renderError(w, http.StatusBadRequest, "Expected JSON request body but received zero bytes")
+		renderError(w, http.StatusBadRequest, "Expected JSON request body but received 0 bytes")
 		return
 	}
 

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -17,11 +17,14 @@ import (
 	"github.com/alphagov/performance-datastore/pkg/config"
 	"github.com/alphagov/performance-datastore/pkg/dataset"
 
+	"reflect"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/types"
 )
 
 type TestDataSetStorage struct {
@@ -55,7 +58,7 @@ func (mock *TestDataSetStorage) SaveRecord(name string, record map[string]interf
 	return mock.error
 }
 
-func (mock *TestDataSetStorage) options(opts []TestDataSetStorageOption) (previous TestDataSetStorageOption) {
+func (mock *TestDataSetStorage) options(opts ...TestDataSetStorageOption) (previous TestDataSetStorageOption) {
 	for _, opt := range opts {
 		previous = opt(mock)
 	}
@@ -98,7 +101,7 @@ func LastUpdated(lastUpdated *time.Time) TestDataSetStorageOption {
 
 func newTestDataSetStorage(options ...TestDataSetStorageOption) dataset.DataSetStorage {
 	result := TestDataSetStorage{}
-	result.options(options)
+	result.options(options...)
 	return &result
 }
 
@@ -189,6 +192,14 @@ func newHandler(maxBodySize int) http.Handler {
 	return NewHandler(maxBodySize, logger)
 }
 
+func newErrorAPIResponse(errorDetail string) APIResponse {
+	return APIResponse{
+		Status:  "error",
+		Message: errorDetail,
+		Errors: []ErrorInfo{
+			ErrorInfo{Detail: errorDetail}}}
+}
+
 var _ = Describe("Handlers", func() {
 
 	var testServer *httptest.Server
@@ -215,9 +226,9 @@ var _ = Describe("Handlers", func() {
 				Expect(err).To(BeNil())
 				Expect(response.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := readResponseBody(response)
-				Expect(err).To(BeNil())
-				Expect(body).To(Equal(`{"message":"database seems fine","status":"ok"}`))
+				Expect(response).To(EqualAPIResponse(APIResponse{
+					Status:  "ok",
+					Message: "database seems fine"}))
 			})
 
 			It("responds to HEAD requests", func() {
@@ -246,17 +257,21 @@ var _ = Describe("Handlers", func() {
 				Expect(err).To(BeNil())
 				Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
 
-				body, err := readResponseBody(response)
-				Expect(err).To(BeNil())
-				Expect(body).To(Equal(`{"errors":[{"detail":"cannot connect to database"}]}`))
+				Expect(response).To(EqualAPIResponse(APIResponse{
+					Status:  "error",
+					Message: "cannot connect to database",
+					Errors: []ErrorInfo{
+						ErrorInfo{Detail: "cannot connect to database"}}}))
 			})
 		})
 	})
 
 	Describe("DataSets", func() {
 
+		var roughly30DaysAgo time.Time
+
 		BeforeEach(func() {
-			roughly30DaysAgo := time.Now().Add(time.Duration(-24*30) * time.Hour)
+			roughly30DaysAgo = time.Now().Add(time.Duration(-24*30) * time.Hour)
 			DataSetStorage = newTestDataSetStorage(Alive(true), LastUpdated(&roughly30DaysAgo))
 		})
 
@@ -270,9 +285,8 @@ var _ = Describe("Handlers", func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 
-			body, err := readResponseBody(response)
-			Expect(err).To(BeNil())
-			Expect(body).To(Equal(`{"status":"ok"}`))
+			Expect(response).To(EqualAPIResponse(APIResponse{
+				Status: "ok"}))
 		})
 
 		It("responds with a status of ruh roh when unable to talk to the config API", func() {
@@ -285,9 +299,9 @@ var _ = Describe("Handlers", func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
 
-			body, err := readResponseBody(response)
-			Expect(err).To(BeNil())
-			Expect(body).To(Equal(`{"errors":[{"detail":"Unable to connect to host"}]}`))
+			Expect(response).To(EqualAPIResponse(APIResponse{Status: "error",
+				Message: "Unable to connect to host",
+				Errors:  []ErrorInfo{ErrorInfo{Detail: "Unable to connect to host"}}}))
 		})
 
 		It("responds with a status of OK when there are no stale datasets", func() {
@@ -303,19 +317,17 @@ var _ = Describe("Handlers", func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 
-			body, err := readResponseBody(response)
-			Expect(err).To(BeNil())
-			Expect(body).To(Equal(`{"status":"ok"}`))
+			Expect(response).To(EqualAPIResponse(APIResponse{Status: "ok"}))
 		})
 
 		It("responds with a status of ruh roh when there are stale datasets", func() {
 			testServer := testHandlerServer(DataSetStatusHandler)
 			defer testServer.Close()
 
-			stale := config.DataSetMetaData{}
-			stale.Published = true
 			maxExpectedAge := int64(8400)
-			stale.MaxExpectedAge = &maxExpectedAge
+			stale := config.DataSetMetaData{Name: "the-stale-one",
+				Published:      true,
+				MaxExpectedAge: &maxExpectedAge}
 
 			ConfigAPIClient = newTestConfigAPIClient(nil, nil,
 				[]config.DataSetMetaData{
@@ -326,9 +338,11 @@ var _ = Describe("Handlers", func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 
-			body, err := readResponseBody(response)
-			Expect(err).To(BeNil())
-			Expect(body).To(Equal(`{"status":"not okay","detail":"1 data-set is out of date"}`))
+			Expect(response).To(EqualAPIResponse(APIResponse{Status: "not okay",
+				Message: "1 data-set is out of date",
+				Errors: []ErrorInfo{
+					ErrorInfo{
+						Detail: "name: the-stale-one, seconds-out-of-date: 2592000, last-updated: " + roughly30DaysAgo.String() + ", max-age-expected: 8400"}}}))
 		})
 	})
 
@@ -359,9 +373,7 @@ var _ = Describe("Handlers", func() {
 				Expect(response.StatusCode).Should(Equal(http.StatusUnauthorized))
 				Expect(response.Header.Get("WWW-Authenticate")).Should(Equal("bearer"))
 
-				body, err := readResponseBody(response)
-				Expect(err).To(BeNil())
-				Expect(body).To(Equal(`{"errors":[{"detail":"Expected header of form: Authorization: Bearer token"}]}`))
+				Expect(response).To(EqualAPIResponse(newErrorAPIResponse("Expected header of form: Authorization: Bearer token")))
 			})
 
 			It("Should fail with an Authorization required response when the Authorization header isn't a valid bearer token", func() {
@@ -377,9 +389,7 @@ var _ = Describe("Handlers", func() {
 				Expect(response.StatusCode).Should(Equal(http.StatusUnauthorized))
 				Expect(response.Header.Get("WWW-Authenticate")).Should(Equal("bearer"))
 
-				body, err := readResponseBody(response)
-				Expect(err).To(BeNil())
-				Expect(body).To(Equal(`{"errors":[{"detail":"Unauthorized: Invalid bearer token '' for 'the-dataset'"}]}`))
+				Expect(response).To(EqualAPIResponse(newErrorAPIResponse("Unauthorized: Invalid bearer token '' for 'the-dataset'")))
 			})
 
 			It("Should fail with an Authorization required response when the Authorization bearer token does not match the data set bearer token", func() {
@@ -395,9 +405,7 @@ var _ = Describe("Handlers", func() {
 				Expect(response.StatusCode).Should(Equal(http.StatusUnauthorized))
 				Expect(response.Header.Get("WWW-Authenticate")).Should(Equal("bearer"))
 
-				body, err := readResponseBody(response)
-				Expect(err).To(BeNil())
-				Expect(body).To(Equal(`{"errors":[{"detail":"Unauthorized: Invalid bearer token '' for 'the-dataset'"}]}`))
+				Expect(response).To(EqualAPIResponse(newErrorAPIResponse("Unauthorized: Invalid bearer token '' for 'the-dataset'")))
 			})
 
 			It("Should fail with an Authorization required response when the Authorization bearer token does not match the data set bearer token", func() {
@@ -413,9 +421,7 @@ var _ = Describe("Handlers", func() {
 				Expect(response.StatusCode).Should(Equal(http.StatusUnauthorized))
 				Expect(response.Header.Get("WWW-Authenticate")).Should(Equal("bearer"))
 
-				body, err := readResponseBody(response)
-				Expect(err).To(BeNil())
-				Expect(body).To(Equal(`{"errors":[{"detail":"Unauthorized: Invalid bearer token '' for 'the-dataset'"}]}`))
+				Expect(response).To(EqualAPIResponse(newErrorAPIResponse("Unauthorized: Invalid bearer token '' for 'the-dataset'")))
 			})
 		})
 
@@ -436,9 +442,7 @@ var _ = Describe("Handlers", func() {
 				Expect(err).Should(BeNil())
 				Expect(response.StatusCode).Should(Equal(http.StatusBadRequest))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"errors":[{"detail":"Expected JSON request body but received zero bytes"}]}`))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Expected JSON request body but received 0 bytes")))
 			})
 
 			It("Should need a JSON request body", func() {
@@ -451,9 +455,7 @@ var _ = Describe("Handlers", func() {
 				Expect(err).Should(BeNil())
 				Expect(response.StatusCode).Should(Equal(http.StatusBadRequest))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"errors":[{"detail":"Error parsing JSON: invalid character 'h' in literal true (expecting 'r')"}]}`))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Error parsing JSON: invalid character 'h' in literal true (expecting 'r')")))
 			})
 
 			It("Should persist the update for a single object", func() {
@@ -466,9 +468,7 @@ var _ = Describe("Handlers", func() {
 				Expect(err).Should(BeNil())
 				Expect(response.StatusCode).Should(Equal(http.StatusOK))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"status":"OK"}`))
+				Expect(response).Should(EqualAPIResponse(APIResponse{Status: "OK"}))
 			})
 
 			It("Should persist the update for an array of objects", func() {
@@ -484,9 +484,7 @@ var _ = Describe("Handlers", func() {
 				Expect(err).Should(BeNil())
 				Expect(response.StatusCode).Should(Equal(http.StatusOK))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"status":"OK"}`))
+				Expect(response).Should(EqualAPIResponse(APIResponse{Status: "OK"}))
 			})
 
 			It("Should fail when provided with invalid data", func() {
@@ -499,9 +497,7 @@ var _ = Describe("Handlers", func() {
 				Expect(err).Should(BeNil())
 				Expect(response.StatusCode).Should(Equal(http.StatusBadRequest))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"errors":[{"detail":"All the errors"}]}`))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("_animal is not a recognised internal field")))
 			})
 
 			Context("With unavailable storage", func() {
@@ -518,14 +514,12 @@ var _ = Describe("Handlers", func() {
 					Expect(err).Should(BeNil())
 					Expect(response.StatusCode).Should(Equal(http.StatusInternalServerError))
 
-					body, err := readResponseBody(response)
-					Expect(err).Should(BeNil())
-					Expect(body).Should(Equal(`{"errors":[{"detail":"Mongo connection is down"}]}`))
+					Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Mongo connection is down")))
 
 					// Check that the dataset was picked out of the context and the correct thing
 					// would have been sent to statsd
 					testStatsd := StatsdClient.(*testStatsdClient)
-					Expect(len(testStatsd.incOps)).Should(Equal(1))
+					Expect(testStatsd.incOps).Should(HaveLen(1))
 					Expect(testStatsd.incOps[0].stat).Should(Equal(`write.error.the-dataset`))
 				})
 			})
@@ -545,14 +539,11 @@ var _ = Describe("Handlers", func() {
 					Expect(err).Should(BeNil())
 					Expect(response.StatusCode).Should(Equal(http.StatusBadRequest))
 
-					body, err := readResponseBody(response)
-					Expect(err).Should(BeNil())
-					Expect(body).Should(Equal(`{"errors":[{"detail":"Error parsing JSON: invalid character '\\x1f' looking for beginning of value"}]}`))
+					Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Error parsing JSON: invalid character '\\x1f' looking for beginning of value")))
 				})
 
 				It("Should fail if the request does not have a body", func() {
-					req, err := http.NewRequest("POST", testServer.URL+"/data/a-data-group/a-data-type",
-						bytes.NewReader([]byte{}))
+					req, err := http.NewRequest("POST", testServer.URL+"/data/a-data-group/a-data-type", nil)
 					req.Header.Add("Authorization", "Bearer the-bearer-token")
 
 					response, err := client.Do(req)
@@ -560,9 +551,7 @@ var _ = Describe("Handlers", func() {
 					Expect(err).Should(BeNil())
 					Expect(response.StatusCode).Should(Equal(http.StatusBadRequest))
 
-					body, err := readResponseBody(response)
-					Expect(err).Should(BeNil())
-					Expect(body).Should(Equal(`{"errors":[{"detail":"Expected JSON request body but received zero bytes"}]}`))
+					Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Expected JSON request body but received 0 bytes")))
 				})
 
 				It("Should succeed if the request has a Content-Encoding header", func() {
@@ -580,9 +569,8 @@ var _ = Describe("Handlers", func() {
 					Expect(err).Should(BeNil())
 					Expect(response.StatusCode).Should(Equal(http.StatusOK))
 
-					body, err := readResponseBody(response)
-					Expect(err).Should(BeNil())
-					Expect(body).Should(Equal(`{"status":"OK"}`))
+					Expect(response).Should(EqualAPIResponse(APIResponse{
+						Status: "OK"}))
 				})
 
 				It("Should fail if the request is too big", func() {
@@ -604,9 +592,7 @@ var _ = Describe("Handlers", func() {
 					Expect(err).Should(BeNil())
 					Expect(response.StatusCode).Should(Equal(http.StatusRequestEntityTooLarge))
 
-					body, err := readResponseBody(response)
-					Expect(err).Should(BeNil())
-					Expect(body).Should(Equal(`{"errors":[{"detail":"Maximum upload size encountered. Treating as a potential zip bomb."}]}`))
+					Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Maximum upload size encountered. Treating as a potential zip bomb.")))
 				})
 			})
 		})
@@ -638,9 +624,7 @@ var _ = Describe("Handlers", func() {
 				Expect(response.StatusCode).Should(Equal(http.StatusUnauthorized))
 				Expect(response.Header.Get("WWW-Authenticate")).Should(Equal("bearer"))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"errors":[{"detail":"Expected header of form: Authorization: Bearer token"}]}`))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Expected header of form: Authorization: Bearer token")))
 			})
 
 			It("Should fail with an Authorization required response when the Authorization header isn't a valid bearer token", func() {
@@ -656,9 +640,7 @@ var _ = Describe("Handlers", func() {
 				Expect(response.StatusCode).Should(Equal(http.StatusUnauthorized))
 				Expect(response.Header.Get("WWW-Authenticate")).Should(Equal("bearer"))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"errors":[{"detail":"Unauthorized: Invalid bearer token '' for 'the-dataset'"}]}`))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Unauthorized: Invalid bearer token '' for 'the-dataset'")))
 			})
 
 			It("Should fail with an Authorization required response when the Authorization bearer token does not match the data set bearer token", func() {
@@ -673,9 +655,7 @@ var _ = Describe("Handlers", func() {
 				Expect(response.StatusCode).Should(Equal(http.StatusUnauthorized))
 				Expect(response.Header.Get("WWW-Authenticate")).Should(Equal("bearer"))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"errors":[{"detail":"Unauthorized: Invalid bearer token '' for 'the-dataset'"}]}`))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Unauthorized: Invalid bearer token '' for 'the-dataset'")))
 			})
 
 			It("Should fail with an Authorization required response when the Authorization bearer token does not match the data set bearer token", func() {
@@ -690,9 +670,7 @@ var _ = Describe("Handlers", func() {
 				Expect(response.StatusCode).Should(Equal(http.StatusUnauthorized))
 				Expect(response.Header.Get("WWW-Authenticate")).Should(Equal("bearer"))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"errors":[{"detail":"Unauthorized: Invalid bearer token '' for 'the-dataset'"}]}`))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Unauthorized: Invalid bearer token '' for 'the-dataset'")))
 			})
 		})
 
@@ -714,9 +692,7 @@ var _ = Describe("Handlers", func() {
 				Expect(err).Should(BeNil())
 				Expect(response.StatusCode).Should(Equal(http.StatusBadRequest))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"errors":[{"detail":"Expected JSON request body but received zero bytes"}]}`))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Expected JSON request body but received 0 bytes")))
 			})
 
 			It("Should need a JSON request body", func() {
@@ -728,9 +704,7 @@ var _ = Describe("Handlers", func() {
 				Expect(err).Should(BeNil())
 				Expect(response.StatusCode).Should(Equal(http.StatusBadRequest))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"errors":[{"detail":"Error parsing JSON: invalid character 'h' in literal true (expecting 'r')"}]}`))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Error parsing JSON: invalid character 'h' in literal true (expecting 'r')")))
 			})
 
 			It("Should persist the update emptying the data set", func() {
@@ -742,9 +716,9 @@ var _ = Describe("Handlers", func() {
 				Expect(err).Should(BeNil())
 				Expect(response.StatusCode).Should(Equal(http.StatusOK))
 
-				body, err := readResponseBody(response)
-				Expect(err).Should(BeNil())
-				Expect(body).Should(Equal(`{"message":"the-dataset now contains 0 records","status":"OK"}`))
+				Expect(response).Should(EqualAPIResponse(APIResponse{
+					Status:  "OK",
+					Message: "the-dataset now contains 0 records"}))
 			})
 
 			It("Should fail to update if the array isn't empty", func() {
@@ -758,11 +732,7 @@ var _ = Describe("Handlers", func() {
 				Expect(err).Should(BeNil())
 				Expect(response.StatusCode).Should(Equal(http.StatusBadRequest))
 
-				doc := Unmarshal(response.Body)
-				errors := doc["errors"].([]interface{})
-				Expect(len(errors)).Should(Equal(1))
-				error := errors[0].(map[string]interface{})
-				Expect(error["detail"]).Should(Equal("Not implemented: you can only pass an empty JSON list"))
+				Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Not implemented: you can only pass an empty JSON list")))
 			})
 
 			Context("With unavailable storage", func() {
@@ -777,12 +747,51 @@ var _ = Describe("Handlers", func() {
 					Expect(err).Should(BeNil())
 					Expect(response.StatusCode).Should(Equal(http.StatusInternalServerError))
 
-					body, err := readResponseBody(response)
-					Expect(err).Should(BeNil())
-					Expect(body).Should(Equal(`{"errors":[{"detail":"Mongo connection is down"}]}`))
+					Expect(response).Should(EqualAPIResponse(newErrorAPIResponse("Mongo connection is down")))
 				})
 			})
 
 		})
 	})
 })
+
+// APIResponseMatcher implements gomega.types.GomegaMatcher
+type APIResponseMatcher struct {
+	expected   APIResponse
+	actualBody string
+}
+
+// EqualAPIResponse is a GomegaMatcher to look at the response from API calls
+func EqualAPIResponse(expected APIResponse) types.GomegaMatcher {
+	return &APIResponseMatcher{expected: expected}
+}
+
+func (matcher *APIResponseMatcher) Match(actual interface{}) (success bool, err error) {
+	response, ok := actual.(*http.Response)
+	if !ok {
+		return false, fmt.Errorf("EqualAPIResponse matcher expects an http.Response")
+	}
+
+	var r APIResponse
+	matcher.actualBody, err = readResponseBody(response)
+
+	if err != nil {
+		return false, fmt.Errorf("Failed to read response: %s", err.Error())
+	}
+
+	err = json.NewDecoder(strings.NewReader(matcher.actualBody)).Decode(&r)
+
+	if err != nil {
+		return false, fmt.Errorf("Failed to decode JSON: %s", err.Error())
+	}
+
+	return reflect.DeepEqual(r, matcher.expected), nil
+}
+
+func (matcher *APIResponseMatcher) FailureMessage(actual interface{}) string {
+	return fmt.Sprintf("Expected\n\t%#v\nto contain the JSON representation of\n\t%#v", matcher.actualBody, matcher.expected)
+}
+
+func (matcher *APIResponseMatcher) NegatedFailureMessage(actual interface{}) string {
+	return fmt.Sprintf("Expected\n\t%#v\nnot to contain the JSON representation of\n\t%#v", matcher.actualBody, matcher.expected)
+}

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -19,7 +19,7 @@ type RequestOptions struct {
 	MaxElapsedTime time.Duration
 }
 
-func (ro *RequestOptions) option(opts []Option) (previous Option) {
+func (ro *RequestOptions) option(opts ...Option) (previous Option) {
 	for _, opt := range opts {
 		previous = opt(ro)
 	}
@@ -46,7 +46,7 @@ func NewRequest(url, bearerToken string, options ...Option) (*http.Response, err
 	request.Header.Add("User-Agent", "Performance-Platform-Client/1.0")
 
 	requestOptions := RequestOptions{MaxElapsedTime: 5 * time.Second}
-	requestOptions.option(options)
+	requestOptions.option(options...)
 
 	response, err := tryGet(client, request, requestOptions)
 


### PR DESCRIPTION
Rework test interface implementations to be configured using variadic
functional configuration => simpler client code.

Use Context more, and extract out common test setup.

Change error response format:
- add status and message field
- allow multiple errors to be rendered
- add Gomega Matcher for checking HTTP API responses
- DRY tests

Probably want [this diff](https://github.com/alphagov/performance-datastore/pull/17/files?w=1).
