### PR TITLE
Fix messy test output by using hijacking

### DIFF
--- a/pkg/request/request_test.go
+++ b/pkg/request/request_test.go
@@ -40,7 +40,18 @@ var _ = Describe("NewRequest", func() {
 
 	It("handles bad networking from the origin server", func() {
 		ts := testServer(func(w http.ResponseWriter, r *http.Request) {
-			panic("Oh dear")
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				panic("webserver doesn't support hijacking – failing the messy way")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				panic("webserver doesn't support hijacking – failing the messy way")
+				return
+			}
+			// Fail in a clean way so that we don't clutter the output
+			conn.Close()
 		})
 		defer ts.Close()
 		// Ensure this isn't a slow test by restricting how many retries happen


### PR DESCRIPTION
The current implementation was using `panic` in the test Handler to:
- cause the test server to fail
- test that the client handles server failures properly

This gives something like the following output when running the tests:

```
goroutine 33 [running]:
net/http.func·011()
    /opt/boxen/homebrew/Cellar/go/1.3.3/libexec/src/pkg/net/http/server.go:1100 +0xb7
runtime.panic(0x293ac0, 0xc2080372b0)
    /opt/boxen/homebrew/Cellar/go/1.3.3/libexec/src/pkg/runtime/panic.c:248 +0x18d
_/Users/jabley/govuk/performance-datastore/pkg/request.func·006(0x618638, 0xc2080666e0, 0xc208000c30)
    /Users/jabley/govuk/performance-datastore/pkg/request/request_test.go:43 +0x61
net/http.HandlerFunc.ServeHTTP(0x419308, 0x618638, 0xc2080666e0, 0xc208000c30)
    /opt/boxen/homebrew/Cellar/go/1.3.3/libexec/src/pkg/net/http/server.go:1235 +0x40
net/http/httptest.(*waitGroupHandler).ServeHTTP(0xc20803ecc0, 0x618638, 0xc2080666e0, 0xc208000c30)
    /opt/boxen/homebrew/Cellar/go/1.3.3/libexec/src/pkg/net/http/httptest/server.go:200 +0xb4
net/http.serverHandler.ServeHTTP(0xc208004d80, 0x618638, 0xc2080666e0, 0xc208000c30)
    /opt/boxen/homebrew/Cellar/go/1.3.3/libexec/src/pkg/net/http/server.go:1673 +0x19f
net/http.(*conn).serve(0xc208046700)
    /opt/boxen/homebrew/Cellar/go/1.3.3/libexec/src/pkg/net/http/server.go:1174 +0xa7e
created by net/http.(*Server).Serve
    /opt/boxen/homebrew/Cellar/go/1.3.3/libexec/src/pkg/net/http/server.go:1721 +0x313
2014/11/02 10:05:12 http: panic serving 127.0.0.1:53505: Oh dear
```

Instead, we can use http://golang.org/pkg/net/http/#Hijacker to cleanly
cause the test server to fail to respond, and avoid noisy test output.

New output now looks like:

```
[1414924974] Request Suite - 4/4 specs •••• SUCCESS! 1.277971394s PASS
coverage: 97.5% of statements
```
