### PR TITLE
Handle not found

### DIFF
--- a/pkg/handlers/mongodb.go
+++ b/pkg/handlers/mongodb.go
@@ -102,6 +102,10 @@ func (m *MongoDataSetStorage) LastUpdated(name string) (t *time.Time) {
 	coll := session.DB(m.DatabaseName).C(name)
 	err := coll.Find(nil).Sort("-_updated_at").One(&lastUpdated)
 
+	if err == mgo.ErrNotFound {
+		return nil
+	}
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
If we try to find the LastUpdated for a data set that does not exist,
we should return nil.
